### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here are some notes on how you should respond in the XML section:
 - Specify each file operation with CREATE, UPDATE, or DELETE
 - If it is a CREATE or UPDATE include the full file code. Do not get lazy.
 - Each file should include a brief change summary.
-- Include the full file path
+- Include only the local file path. Do not include the full root path.
 - I am going to copy/paste that entire XML section into a parser to automatically apply the changes you made, so put the XML block inside a markdown codeblock.
 - Make sure to enclose the code with ![CDATA[__CODE HERE__]]
 


### PR DESCRIPTION
Update format prompt in accordance with Repo Prompt's update.

Repo Prompt recently started providing the full root file path in the file tree instead of just the working directory, causing o1-pro to return full file paths in it's responses. This breaks o1-xml-parser because it assumes the directory starts from within the project, not from root.

This proposed update to the prompt ensure o1-pro only returns the file path starting from the project directory, not the full directory from root.